### PR TITLE
chore: Use Rust 1.80; drop once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 futures-util = "0.3.30"
 i18n-embed-fl = "0.9.1"
-once_cell = "1.19.0"
 open = "5.3.0"
 rust-embed = "8.5.0"
 tokio = { version = "1.40.0", features = ["full"] }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -2,12 +2,13 @@
 
 //! Provides localization support for this crate.
 
+use std::sync::LazyLock;
+
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
     unic_langid::LanguageIdentifier,
     DefaultLocalizer, LanguageLoader, Localizer,
 };
-use once_cell::sync::Lazy;
 use rust_embed::RustEmbed;
 
 /// Applies the requested language(s) to requested translations from the `fl!()` macro.
@@ -27,7 +28,7 @@ pub fn localizer() -> Box<dyn Localizer> {
 #[folder = "i18n/"]
 struct Localizations;
 
-pub static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
+pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
     let loader: FluentLanguageLoader = fluent_language_loader!();
 
     loader


### PR DESCRIPTION
`libcosmic` already requires Rust 1.80.