### PR TITLE
Set minimum window size

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@
 
 use crate::config::Config;
 use crate::fl;
-use cosmic::app::{Core, Task};
+use cosmic::app::{context_drawer, Core, Task};
 use cosmic::cosmic_config::{self, CosmicConfigEntry};
 use cosmic::iced::alignment::{Horizontal, Vertical};
 use cosmic::iced::{Alignment, Length, Subscription};
@@ -114,7 +114,7 @@ impl Application for AppModel {
             menu::root(fl!("view")),
             menu::items(
                 &self.key_binds,
-                vec![menu::Item::Button(fl!("about"), MenuAction::About)],
+                vec![menu::Item::Button(fl!("about"), None, MenuAction::About)],
             ),
         )]);
 
@@ -127,13 +127,17 @@ impl Application for AppModel {
     }
 
     /// Display a context drawer if the context page is requested.
-    fn context_drawer(&self) -> Option<Element<Self::Message>> {
+    fn context_drawer(&self) -> Option<context_drawer::ContextDrawer<Self::Message>> {
         if !self.core.window.show_context {
             return None;
         }
 
         Some(match self.context_page {
-            ContextPage::About => self.about(),
+            ContextPage::About => context_drawer::context_drawer(
+                self.about(),
+                Message::ToggleContextPage(ContextPage::About),
+            )
+            .title(fl!("about")),
         })
     }
 
@@ -205,9 +209,6 @@ impl Application for AppModel {
                     self.context_page = context_page;
                     self.core.window.show_context = true;
                 }
-
-                // Set the title of the context drawer.
-                self.set_context_title(context_page.title());
             }
 
             Message::UpdateConfig(config) => {
@@ -277,14 +278,6 @@ pub enum Page {
 pub enum ContextPage {
     #[default]
     About,
-}
-
-impl ContextPage {
-    fn title(&self) -> String {
-        match self {
-            Self::About => fl!("about"),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,11 @@ fn main() -> cosmic::iced::Result {
     i18n::init(&requested_languages);
 
     // Settings for configuring the application window and iced runtime.
-    let settings = cosmic::app::Settings::default();
+    let settings = cosmic::app::Settings::default().size_limits(
+        cosmic::iced::Limits::NONE
+            .min_width(360.0)
+            .min_height(180.0),
+    );
 
     // Starts the application's event loop with `()` as the application's flags.
     cosmic::app::run::<app::AppModel>(settings, ())


### PR DESCRIPTION
Sets the minimum window size to 360x180, to match other COSMIC apps.
Also updates libcosmic.
Fixes #11.

Mainly added this since some apps using the template can be resized to 0, which doesn't look great. So this increases the visibility of the option.