### PR TITLE
improv: Include build git commit hash in 'About' page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "cosmic-app-template"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/pop-os/cosmic-app-template"
+
+[build-dependencies]
+vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dependencies]
 futures-util = "0.3.31"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Log into your GitHub account and click the "Use this template" button above. Thi
 - Rename the file `i18n/en/cosmic_app_template.ftl` by replacing the `cosmic_app_template` portion with the new crate `name` you set in `Cargo.toml`.
 - In `justfile`, change the `name` and `appid` variables with your own.
 - In `src/app.rs`, change the `APP_ID` value in the `Application` implementation of the `AppModel`.
-- In `src/app.rs`, change the `REPOSITORY` const with the URL to your application's git repository.
 - In `res/app.desktop`, change the `Name=`, `Exec=`, and `Icon=` fields
 - Set your license within the SPDX tags at the top of each source file
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Rebuild if i18n files change
+    println!("cargo:rerun-if-changed=i18n");
+
+    // Emit version information (if not cached by just vendor)
+    let mut vergen = vergen::EmitBuilder::builder();
+
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_COMMIT_DATE");
+    if std::env::var_os("VERGEN_GIT_COMMIT_DATE").is_none() {
+        vergen.git_commit_date();
+    }
+
+    println!("cargo:rerun-if-env-changed=VERGEN_GIT_SHA");
+    if std::env::var_os("VERGEN_GIT_SHA").is_none() {
+        vergen.git_sha(false);
+    }
+    vergen.fail_on_error().emit()?;
+    Ok(())
+}

--- a/i18n/en/cosmic_app_template.ftl
+++ b/i18n/en/cosmic_app_template.ftl
@@ -3,3 +3,4 @@ about = About
 view = View
 welcome = Welcome to COSMIC! ✨
 page-id = Page { $num }
+git-description = Git commit {$hash} on {$date}

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use cosmic::{cosmic_theme, theme, Application, ApplicationExt, Apply, Element};
 use futures_util::SinkExt;
 use std::collections::HashMap;
 
-const REPOSITORY: &str = "https://github.com/pop-os/cosmic-app-template";
+const REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 const APP_ICON: &[u8] = include_bytes!("../res/icons/hicolor/scalable/apps/icon.svg");
 
 /// The application model stores app-specific state used to describe its interface and
@@ -36,6 +36,7 @@ pub enum Message {
     SubscriptionChannel,
     ToggleContextPage(ContextPage),
     UpdateConfig(Config),
+    LaunchUrl(String),
 }
 
 /// Create a COSMIC application from the app model
@@ -214,6 +215,13 @@ impl Application for AppModel {
             Message::UpdateConfig(config) => {
                 self.config = config;
             }
+
+            Message::LaunchUrl(url) => match open::that_detached(&url) {
+                Ok(()) => {}
+                Err(err) => {
+                    eprintln!("failed to open {url:?}: {err}");
+                }
+            },
         }
         Task::none()
     }
@@ -236,6 +244,10 @@ impl AppModel {
 
         let title = widget::text::title3(fl!("app-title"));
 
+        let hash = env!("VERGEN_GIT_SHA");
+        let short_hash: String = hash.chars().take(7).collect();
+        let date = env!("VERGEN_GIT_COMMIT_DATE");
+
         let link = widget::button::link(REPOSITORY)
             .on_press(Message::OpenRepositoryUrl)
             .padding(0);
@@ -244,6 +256,15 @@ impl AppModel {
             .push(icon)
             .push(title)
             .push(link)
+            .push(
+                widget::button::link(fl!(
+                    "git-description",
+                    hash = short_hash.as_str(),
+                    date = date
+                ))
+                .on_press(Message::LaunchUrl(format!("{REPOSITORY}/commits/{hash}")))
+                .padding(0),
+            )
             .align_x(Alignment::Center)
             .spacing(space_xxs)
             .into()

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -13,7 +13,7 @@ use rust_embed::RustEmbed;
 
 /// Applies the requested language(s) to requested translations from the `fl!()` macro.
 pub fn init(requested_languages: &[LanguageIdentifier]) {
-    if let Err(why) = localizer().select(&requested_languages) {
+    if let Err(why) = localizer().select(requested_languages) {
         eprintln!("error while loading fluent localizations: {why}");
     }
 }


### PR DESCRIPTION
Changes based on COSMIC Files source.

Also removed redundant Git repository entries in both Cargo manifest TOML and in src/app.rs, by instead using the env var set at compile time by Cargo ("CARGO_PKG_REPOSITORY"), which is set from the 'repository' key in the Cargo manifest TOML