### PR TITLE
improv: added appdata metainfo file (#14)

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,6 +13,10 @@ desktop := appid + '.desktop'
 desktop-src := 'resources' / desktop
 desktop-dst := clean(rootdir / prefix) / 'share' / 'applications' / desktop
 
+appdata := appid + '.metainfo.xml'
+appdata-src := 'resources' / appdata
+appdata-dst := clean(rootdir / prefix) / 'share' / 'appdata' / appdata
+
 icons-src := 'resources' / 'icons' / 'hicolor'
 icons-dst := clean(rootdir / prefix) / 'share' / 'icons' / 'hicolor'
 
@@ -57,7 +61,8 @@ run *args:
 # Installs files
 install:
     install -Dm0755 {{bin-src}} {{bin-dst}}
-    install -Dm0644 res/app.desktop {{desktop-dst}}
+    install -Dm0644 resources/app.desktop {{desktop-dst}}
+    install -Dm0644 resources/app.metainfo.xml {{appdata-dst}}
     install -Dm0644 {{icon-svg-src}} {{icon-svg-dst}}
 
 # Uninstalls installed files

--- a/resources/app.metainfo.xml
+++ b/resources/app.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>{{ appid }}</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>{{ license }}</project_license>
+  <name>{{ project-name | title_case }}</name>
+  <summary>{{ description }}</summary>
+  <icon type="remote" width="64" height="64" scale="1">
+    {{ repository-url }}/raw/main/resources/icons/hicolor/scalable/apps/icon.svg
+  </icon>
+  <url type="vcs-browser">{{ repository-url }}</url>
+  <launchable type="desktop-id">{{ appid }}.desktop</launchable>
+  <provides>
+    <id>{{ appid }}</id>
+    <binaries>
+      <binary>{{ project-name }}</binary>
+    </binaries>
+  </provides>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+  <categories>
+    <category>COSMIC</category>
+  </categories>
+  <keywords>
+    <keyword>COSMIC</keyword>
+  </keywords>
+  <content_rating type="oars-1.1" />
+</component>
+


### PR DESCRIPTION
Resolves issue #14.

Adds a `app.metainfo.xml` file to the `resources` directory. `justfile` was also updated to install this file on the system.

Also fixed an issue where the install steps in the `justfile` were outdated, and still pointed to `res/app.desktop` instead of `resources/app.desktop`.