### PR TITLE
fix: cargo generate app id regex optional fourth param

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -2,7 +2,7 @@
 cargo_generate_version = ">=0.22"
 
 [placeholders]
-appid = { type = "string", prompt = "App ID (com.example.MyCosmicApp)", regex = "^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+\\.[a-zA-Z0-9]+\\.[a-zA-Z0-9]*$" }
+appid = { type = "string", prompt = "App ID (com.example.MyCosmicApp)", regex = "^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+\\.[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)?$" }
 description = { type = "string", prompt = "App description:", default = "An application for the COSMIC™ desktop" }
 license = { type = "string", prompt = "SPDX license identifier (https://spdx.org/licenses/)", default = "MPL-2.0" }
 repository-url = { type = "string", prompt = "Repository URL (https://*)", regex = "^https?:\\/\\/(www\\.)?[\\w\\-]+(\\.[\\w\\-]+)+[/#?]?.*$" }


### PR DESCRIPTION
Fixes app id parsing problem from #18 