### PR TITLE
handle justfile as raw for cargo-generate

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 name := '{{ project-name }}'
 appid := '{{ appid }}'
-
+{% raw %}
 rootdir := ''
 prefix := '/usr'
 
@@ -93,3 +93,4 @@ vendor:
 vendor-extract:
     rm -rf vendor
     tar pxf vendor.tar
+{% endraw %}


### PR DESCRIPTION
Currently, all the {{var}} are removed from the justfile when using cargo-gen this makes it so the justfile actually works
