### PR TITLE
fix: specify emitter type in iced_futures::stream::channel subscription

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -260,7 +260,7 @@ impl cosmic::Application for AppModel {
         // Conditionally enables a timer that emits a message every second.
         if self.watch_is_active {
             subscriptions.push(Subscription::run(|| {
-                iced_futures::stream::channel(1, |mut emitter| async move {
+                iced_futures::stream::channel(1, |mut emitter: iced_futures::futures::channel::mpsc::Sender| async move {
                     let mut time = 1;
                     let mut interval = tokio::time::interval(Duration::from_secs(1));
 


### PR DESCRIPTION
Explicitly defines the `Sender` type for the `emitter` parameter in `iced_futures::stream::channel`. 

This change resolves a type inference ambiguity that was preventing successful compilation.

Closes #35